### PR TITLE
add useLocalStorage for Favorites

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -35,7 +35,12 @@ export default function App({ Component, pageProps }) {
     setComments(updatedComments); // State setzen
   };
 
-  const [artPiecesInfo, setArtPiecesInfo] = useState([]);
+  const [artPiecesInfo, setArtPiecesInfo] = useLocalStorageState(
+    "artPiecesInfo",
+    {
+      defaultValue: [],
+    }
+  );
 
   function handleToggleFavorite(slug) {
     const isAlreadyFavorite = artPiecesInfo.find((info) => info.slug === slug);


### PR DESCRIPTION
Closes #8

## Feature: Persist Favorites in Local Storage

### What I did
- Added `useLocalStorage` for saving favorite art pieces.
- Favorites are now persisted after page reload.
- Comments were already using `useLocalStorage`, so no changes were needed there.

### Result
Favorites and comments stay saved in the browser even after refreshing the app.